### PR TITLE
Improve authentication screen

### DIFF
--- a/app/src/main/java/com/paraskcd/unitedsetups/MainActivity.kt
+++ b/app/src/main/java/com/paraskcd/unitedsetups/MainActivity.kt
@@ -61,14 +61,7 @@ class MainActivity : ComponentActivity() {
     @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge(
-            statusBarStyle = SystemBarStyle.dark(
-                DarkColorScheme.surface.hashCode()
-            ),
-            navigationBarStyle = SystemBarStyle.dark(
-                DarkColorScheme.surface.hashCode()
-            )
-        )
+        enableEdgeToEdge()
         setContent {
             val mainViewModel: MainActivityViewModel = hiltViewModel()
             val authenticationViewModel: AuthenticationViewModel = hiltViewModel()
@@ -246,7 +239,6 @@ class MainActivity : ComponentActivity() {
                         authenticationViewModel = authenticationViewModel
                     )
                 }
-
             }
         }
     }

--- a/app/src/main/java/com/paraskcd/unitedsetups/presentation/authentication/AuthenticationView.kt
+++ b/app/src/main/java/com/paraskcd/unitedsetups/presentation/authentication/AuthenticationView.kt
@@ -1,10 +1,10 @@
 package com.paraskcd.unitedsetups.presentation.authentication
 
+import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -39,14 +40,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
-import com.paraskcd.unitedsetups.presentation.components.EmailTextField
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.paraskcd.unitedsetups.R
+import com.paraskcd.unitedsetups.presentation.components.EmailTextField
 import com.paraskcd.unitedsetups.ui.theme.DarkColorScheme
 import com.paraskcd.unitedsetups.ui.theme.NoRippleConfiguration
 import kotlinx.coroutines.launch
@@ -54,6 +56,7 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AuthenticationView(modifier: Modifier = Modifier, authenticationViewModel: AuthenticationViewModel) {
+    val context = LocalContext.current
     var register by remember { mutableStateOf(false) }
     var showPassword by remember { mutableStateOf(false) }
     val composableScope = rememberCoroutineScope()
@@ -205,6 +208,12 @@ fun AuthenticationView(modifier: Modifier = Modifier, authenticationViewModel: A
                                 val error = authenticationViewModel.register()
                                 if (error == null) {
                                     register = false
+                                } else {
+                                    Toast.makeText(
+                                        context,
+                                        error.message,
+                                        Toast.LENGTH_SHORT
+                                    ).show()
                                 }
                             } else {
                                 authenticationViewModel.login()
@@ -251,6 +260,17 @@ fun AuthenticationView(modifier: Modifier = Modifier, authenticationViewModel: A
                     }
                 }
             }
+        }
+    }
+
+    if (authenticationViewModel.isLoading) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.5f)),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
         }
     }
 }

--- a/app/src/main/java/com/paraskcd/unitedsetups/presentation/authentication/AuthenticationView.kt
+++ b/app/src/main/java/com/paraskcd/unitedsetups/presentation/authentication/AuthenticationView.kt
@@ -1,13 +1,16 @@
 package com.paraskcd.unitedsetups.presentation.authentication
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
@@ -17,13 +20,16 @@ import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalRippleConfiguration
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -42,8 +48,10 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.paraskcd.unitedsetups.R
 import com.paraskcd.unitedsetups.ui.theme.DarkColorScheme
+import com.paraskcd.unitedsetups.ui.theme.NoRippleConfiguration
 import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AuthenticationView(modifier: Modifier = Modifier, authenticationViewModel: AuthenticationViewModel) {
     var register by remember { mutableStateOf(false) }
@@ -71,7 +79,8 @@ fun AuthenticationView(modifier: Modifier = Modifier, authenticationViewModel: A
                         DarkColorScheme.surface,
                         shape = RoundedCornerShape(16.dp)
                     )
-                    .padding(16.dp),
+                    .padding(16.dp)
+                    .animateContentSize(),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Image(
@@ -204,7 +213,8 @@ fun AuthenticationView(modifier: Modifier = Modifier, authenticationViewModel: A
                     },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp),
+                        .heightIn(min = 48.dp),
+                    shape = RoundedCornerShape(16.dp),
                     enabled =
                         if (register) {
                             authenticationViewModel.username.isNotBlank()
@@ -222,19 +232,22 @@ fun AuthenticationView(modifier: Modifier = Modifier, authenticationViewModel: A
                         Text("Login")
                     }
                 }
-                TextButton(
-                    onClick = {
-                        register = !register
-                        authenticationViewModel.updateEmail("")
-                        authenticationViewModel.updatePassword("")
-                        authenticationViewModel.updateName("")
-                        authenticationViewModel.updateUsername("")
-                    }
-                ) {
-                    if (register) {
-                        Text("Already have an account? Tap here to login")
-                    } else {
-                        Text("Don't have an account? Tap here to register")
+                CompositionLocalProvider(LocalRippleConfiguration provides NoRippleConfiguration) {
+                    TextButton(
+                        modifier = Modifier.padding(top = 16.dp),
+                        onClick = {
+                            register = !register
+                            authenticationViewModel.updateEmail("")
+                            authenticationViewModel.updatePassword("")
+                            authenticationViewModel.updateName("")
+                            authenticationViewModel.updateUsername("")
+                        }
+                    ) {
+                        if (register) {
+                            Text("Already have an account? Tap here to login")
+                        } else {
+                            Text("Don't have an account? Tap here to register")
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/paraskcd/unitedsetups/presentation/authentication/AuthenticationView.kt
+++ b/app/src/main/java/com/paraskcd/unitedsetups/presentation/authentication/AuthenticationView.kt
@@ -1,5 +1,6 @@
 package com.paraskcd.unitedsetups.presentation.authentication
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -48,6 +49,10 @@ fun AuthenticationView(modifier: Modifier = Modifier, authenticationViewModel: A
     var register by remember { mutableStateOf(false) }
     var showPassword by remember { mutableStateOf(false) }
     val composableScope = rememberCoroutineScope()
+
+    BackHandler(enabled = register) {
+        register = false
+    }
 
     Box(modifier = Modifier.fillMaxSize().background(DarkColorScheme.background)) {
         Image(

--- a/app/src/main/java/com/paraskcd/unitedsetups/presentation/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/paraskcd/unitedsetups/presentation/authentication/AuthenticationViewModel.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import com.paraskcd.unitedsetups.core.common.TokenManager
 import com.paraskcd.unitedsetups.core.interfaces.repository.IAuthApiRepository
-import com.paraskcd.unitedsetups.data.repository.authentication.AuthApiRepository
 import com.paraskcd.unitedsetups.core.requests.authentication.LoginRequest
 import com.paraskcd.unitedsetups.core.requests.authentication.RegisterRequest
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -32,6 +31,9 @@ class AuthenticationViewModel @Inject constructor(
     var isLoggedIn by mutableStateOf(false)
         private set
 
+    var isLoading by mutableStateOf(false)
+        private set
+
     fun updateEmail(input: String) {
         email = input
     }
@@ -49,13 +51,17 @@ class AuthenticationViewModel @Inject constructor(
     }
 
     suspend fun login() {
+        isLoading = true
         val response = authApiRepository.Login(LoginRequest(email, password))
         tokenManager.saveToken(authData = response.data)
         isLoggedIn = true
+        isLoading = false
     }
 
     suspend fun register(): Exception? {
+        isLoading = true
         val response = authApiRepository.Register(RegisterRequest(username, email, name, password))
+        isLoading = false
         return response.ex
     }
 }

--- a/app/src/main/java/com/paraskcd/unitedsetups/presentation/components/PostThreadItem.kt
+++ b/app/src/main/java/com/paraskcd/unitedsetups/presentation/components/PostThreadItem.kt
@@ -72,7 +72,6 @@ fun PostThreadItem(
         modifier = Modifier
             .padding(horizontal = firstPadding())
             .fillMaxWidth()
-            .shadow(elevation = 16.dp)
             .background(
                 DarkColorScheme.surface,
                 shape = getShape()

--- a/app/src/main/java/com/paraskcd/unitedsetups/presentation/main/screens/NewPost/NewPost.kt
+++ b/app/src/main/java/com/paraskcd/unitedsetups/presentation/main/screens/NewPost/NewPost.kt
@@ -1,5 +1,6 @@
 package com.paraskcd.unitedsetups.presentation.main.screens.NewPost
 
+import android.app.Activity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -11,9 +12,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -25,27 +23,24 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -53,7 +48,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
@@ -63,7 +60,6 @@ import com.paraskcd.unitedsetups.ui.theme.DarkColorScheme
 import kotlinx.coroutines.android.awaitFrame
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NewPost(navController: NavHostController, modifier: Modifier = Modifier) {
     val newPostViewModel: NewPostViewModel = hiltViewModel()
@@ -101,7 +97,14 @@ fun NewPost(navController: NavHostController, modifier: Modifier = Modifier) {
         focusRequester.requestFocus()
     }
 
+    val window = (LocalView.current.context as Activity).window
+    val navbarColor = DarkColorScheme.surface.toArgb()
+
     if (loading) {
+        SideEffect {
+            window.navigationBarColor = Color.Transparent.toArgb()
+        }
+
         Box(modifier = Modifier.fillMaxSize().background(DarkColorScheme.background), contentAlignment = Alignment.Center) {
             Column(verticalArrangement = Arrangement.Center, horizontalAlignment = Alignment.CenterHorizontally) {
                 CircularProgressIndicator(
@@ -115,6 +118,14 @@ fun NewPost(navController: NavHostController, modifier: Modifier = Modifier) {
             }
         }
     } else {
+        DisposableEffect(Unit) {
+            window.navigationBarColor = navbarColor
+
+            onDispose {
+                window.navigationBarColor = Color.Transparent.toArgb()
+            }
+        }
+
         Column(
             modifier = modifier
                 .fillMaxSize(),

--- a/app/src/main/java/com/paraskcd/unitedsetups/presentation/main/screens/Post/Post.kt
+++ b/app/src/main/java/com/paraskcd/unitedsetups/presentation/main/screens/Post/Post.kt
@@ -1,5 +1,6 @@
 package com.paraskcd.unitedsetups.presentation.main.screens.Post
 
+import android.app.Activity
 import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
@@ -50,9 +51,11 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.outlined.Forum
 import androidx.compose.material3.VerticalDivider
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalView
 import androidx.core.content.ContextCompat.startActivity
 import com.paraskcd.unitedsetups.presentation.components.PostThreadItem
 
@@ -72,6 +75,9 @@ fun Post(postId: String, navController: NavHostController, viewModel: PostViewMo
     val localDensity = LocalDensity.current
     val localContext = LocalContext.current
     val replyPostThread by remember { viewModel.replyParentPostThread }
+
+    val window = (LocalView.current.context as Activity).window
+    val navbarColor = DarkColorScheme.surface.toArgb()
 
     LaunchedEffect(postId) {
         viewModel.getPostById(postId)
@@ -121,6 +127,13 @@ fun Post(postId: String, navController: NavHostController, viewModel: PostViewMo
         },
         contentAlignment = Alignment.BottomCenter
     ) {
+        DisposableEffect(Unit) {
+            window.navigationBarColor = navbarColor
+
+            onDispose {
+                window.navigationBarColor = Color.Transparent.toArgb()
+            }
+        }
         LazyColumn(modifier = Modifier.fillMaxSize()) {
             item {
                 Spacer(modifier = Modifier.height(24.dp))
@@ -162,12 +175,12 @@ fun Post(postId: String, navController: NavHostController, viewModel: PostViewMo
             exit = shrinkVertically(shrinkTowards = Alignment.Top)
         ) {
             Column(
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
                     .background(DarkColorScheme.surface, shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp))
                     .onGloballyPositioned { coordinates ->
                         columnHeightDp = with(localDensity) { coordinates.size.height.toDp() }
                     }
-                    .safeDrawingPadding()
             ) {
                 replyPostThread?.let { postThread ->
                     Row (
@@ -211,6 +224,7 @@ fun Post(postId: String, navController: NavHostController, viewModel: PostViewMo
                         disabledIndicatorColor = Color.Transparent,
                         errorIndicatorColor = DarkColorScheme.error
                     ),
+                    maxLines = 22,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(bottom = 16.dp)

--- a/app/src/main/java/com/paraskcd/unitedsetups/ui/theme/Theme.kt
+++ b/app/src/main/java/com/paraskcd/unitedsetups/ui/theme/Theme.kt
@@ -1,6 +1,9 @@
 package com.paraskcd.unitedsetups.ui.theme
 
+import androidx.compose.material.ripple.RippleAlpha
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RippleConfiguration
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
@@ -32,3 +35,14 @@ fun UnitedSetupsTheme(
         content = content
     )
 }
+
+@OptIn(ExperimentalMaterial3Api::class)
+val NoRippleConfiguration =
+    RippleConfiguration(
+        color = Color.Transparent, rippleAlpha = RippleAlpha(
+            draggedAlpha = 0f,
+            focusedAlpha = 0f,
+            hoveredAlpha = 0f,
+            pressedAlpha = 0f
+        )
+    )


### PR DESCRIPTION
- [Fixed edge to edge mode](https://github.com/unitedsetups/android/commit/66dca8c3a3abcc620b3c7fa9859c10edda25c082)
- [Fixed back handler on register screen](https://github.com/unitedsetups/android/commit/d4f80afc770f6284b722dd83ccc177db778e3293)
- [Make button size and radius similar to input fields](https://github.com/unitedsetups/android/commit/82c48ed1a4da78b1c074d8d22a78d34cfe8fe657)
- [Disable ripple effect for text button](https://github.com/unitedsetups/android/commit/82c48ed1a4da78b1c074d8d22a78d34cfe8fe657)
- [Animate switching between login and register](https://github.com/unitedsetups/android/commit/82c48ed1a4da78b1c074d8d22a78d34cfe8fe657)
- [Show loading indicator and error toast for authentication](https://github.com/unitedsetups/android/commit/f25ffa4b8a9ad5eaf477e86aaa47e58ec9f5fbc6)